### PR TITLE
Use rprojroot

### DIFF
--- a/01_clean.R
+++ b/01_clean.R
@@ -27,7 +27,7 @@ popn <- read.csv("Z:/sustainability/population/Population_Estimates.csv", string
 
 ## loading tabular regional district population data from 1986-2015
 ## downloaded via search tool under Population by Age and Sex, first cell renamed to SGC for machine readable format
-popn_bc <- read.csv("Z:/sustainability//population/BC_annual_population_estimates.csv", stringsAsFactors = FALSE)
+popn_bc <- read.csv("Z:/sustainability/population/BC_annual_population_estimates.csv", stringsAsFactors = FALSE)
 
 
 ## preparing regional district map for census division population display and area

--- a/01_clean.R
+++ b/01_clean.R
@@ -14,6 +14,7 @@ library(dplyr) #data munging
 library(tidyr) #for reformatting dataframes
 library(reshape2) #format dataframe
 library(rgdal) #for reading shapefile
+library(rgeos)
 library(envreportutils) #for order dataframe function
 library(bcmaps) #for regional district map plot; package & details on GitHub -- https://github.com/bcgov/bcmaps
 
@@ -35,7 +36,7 @@ cd <- regional_districts_disp
 cd_area <- regional_districts_analysis
  
 ## extract regional district area values
-area_vector <- sapply(slot(cd, "polygons"), slot, "area")
+area_vector <- gArea(cd, byid = TRUE)
 area_df <- data.frame(SGC = cd_area$CDUID, area = area_vector)
 
 ## format population values in BC dataframe
@@ -104,7 +105,7 @@ popn_rest <- order_df(popn_rest, target_col = "Regional.District",
 ## join popn_sum and regional district area dataframes to calculate population density
 popn_sum <- left_join(popn_sum, area_df, by = c("SGC" = "SGC"))
 popn_sum <- popn_sum %>%
-  mutate(density = round(Total/(area/10^6), 0)) 
+  mutate(density = round(Total/(area/10^6), 0))
 
 ## create density labels and categories for plotting density map
 catlab <- c("less than 10", "10 to 60", "61 to 200", "greater than 800")

--- a/02_output.R
+++ b/02_output.R
@@ -21,6 +21,9 @@ library(ggplot2) #for plotting
 library(RColorBrewer) #for colour palette
 library(png) #for inserting image to plot
 library(grid) #for creating grid graphic
+library(rprojroot)
+
+root <- rprojroot::is_rstudio_project
 
 ## create a folder to store the output plots
 dir.create('out', showWarnings = FALSE)
@@ -43,7 +46,7 @@ cd_plot <- fortify(cd, region = "CDUID")
 cd_plot <- left_join(cd_plot, popn_sum, by = c("id" = "SGC"))
 
 ## preparing image to insert to BC line graph
-img <- readPNG("../source_image/popn.png")
+img <- readPNG(root$find_file(file.path("source_image", "popn.png")))
 g <- rasterGrob(img, interpolate = TRUE)
 
 

--- a/02_output.R
+++ b/02_output.R
@@ -23,6 +23,7 @@ library(png) #for inserting image to plot
 library(grid) #for creating grid graphic
 library(rprojroot)
 
+## Find the root of the project so we can find the files in the directory tree.
 root <- rprojroot::is_rstudio_project
 
 ## create a folder to store the output plots
@@ -46,7 +47,8 @@ cd_plot <- fortify(cd, region = "CDUID")
 cd_plot <- left_join(cd_plot, popn_sum, by = c("id" = "SGC"))
 
 ## preparing image to insert to BC line graph
-img <- readPNG(root$find_file(file.path("source_image", "popn.png")))
+img_path <- root$find_file(file.path("source_image", "popn.png"))
+img <- readPNG(img_path)
 g <- rasterGrob(img, interpolate = TRUE)
 
 

--- a/print_ver/popn.Rmd
+++ b/print_ver/popn.Rmd
@@ -21,6 +21,7 @@ library(grid) #for creating grid graphic
 library(knitr) #for outputing PDF
 library(rprojroot)
 
+## Find the root of the project so we can find the files in the directory tree.
 root <- rprojroot::is_rstudio_project
 
 opts_chunk$set(echo=FALSE, cache=FALSE, warning=FALSE, message=FALSE, error=FALSE,

--- a/print_ver/popn.Rmd
+++ b/print_ver/popn.Rmd
@@ -19,10 +19,14 @@ library(RColorBrewer) #for colour palette
 library(png) #for inserting image to plot
 library(grid) #for creating grid graphic
 library(knitr) #for outputing PDF
+library(rprojroot)
+
+root <- rprojroot::is_rstudio_project
 
 opts_chunk$set(echo=FALSE, cache=FALSE, warning=FALSE, message=FALSE, error=FALSE,
                fig.height = 5.5)
-read_chunk("../02_output.R")
+source(root$find_file("01_clean.R"))
+read_chunk(root$find_file("02_output.R"))
 ```
 
 ```{r pre}


### PR DESCRIPTION
This uses the [rprojroot](https://github.com/krlmlr/rprojroot) package to help find the root of the project directory. It allows accessing a file in the R script or Rmd doc from different levels in the project's directory tree.

Unrelated: I also changed the area calculation of the census division polygons to use `rgeos::gArea` function. Using `sapply(slot(cd, "polygons"), slot, "area")` doesn't account for holes in polygons... probably not an issue in this case as I don't think there are holes in the census division polygons, but it's still safer I think.
